### PR TITLE
Add missing dependency and fix resume from checkpoint

### DIFF
--- a/fine-tuning/requirements.txt
+++ b/fine-tuning/requirements.txt
@@ -6,3 +6,4 @@ rouge-score
 nltk
 py7zr
 torch >= 1.3
+transformers

--- a/fine-tuning/run_summarization.py
+++ b/fine-tuning/run_summarization.py
@@ -573,8 +573,7 @@ def main():
             checkpoint = training_args.resume_from_checkpoint
         elif last_checkpoint is not None:
             checkpoint = last_checkpoint
-        # train_result = trainer.train(resume_from_checkpoint=checkpoint)
-        train_result = trainer.train()
+        train_result = trainer.train() if not checkpoint else trainer.train(resume_from_checkpoint=checkpoint)
         trainer.save_model()  # Saves the tokenizer too for easy upload
 
         metrics = train_result.metrics


### PR DESCRIPTION
Hey, thank you for making your work reproducible!
While running the `fine-tuning/run_rummarization.py` script, I ran into the following error:
```
Traceback (most recent call last):
  File "run_summarization.py", line 32, in <module>
    import transformers
ModuleNotFoundError: No module named 'transformers
```

After installing that, I can run the script (it is currently training).
Moreover, I noticed that training wouldn't resume from the last saved checkpoint because the `resume_from_checkpoint` option wasn't passed to `trainer.train()`

Signed-off-by: Florian Aumeier <hey@flo.fish>